### PR TITLE
Update PyPI release trigger

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   release:
-    types: [created]
+    types: [published]
 
 # based on https://github.com/pypa/gh-action-pypi-publish
 


### PR DESCRIPTION
The PyPI release workflow wasn't triggered by the `release` event type as reported by @rohitgr7. The exact reason is still unknown, but it could be due to `types: [created]`. This PR updates the trigger so that it all aligns across our repositories' settings.

See the workflow file in our repo: https://github.com/Lightning-AI/lightning/blob/4750e221d1e7622bbf2d0e5b09e7136032e9c410/.github/workflows/release-pypi.yml#L8